### PR TITLE
ensure htmlentities are used in attributes

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -12,6 +12,10 @@ from __future__ import unicode_literals
 from future.utils import with_metaclass
 from builtins import object
 from io import open
+try:
+    from html import escape  # python 3.x
+except ImportError:
+    from cgi import escape  # python 2.x
 
 try:
     import itertools.izip as zip
@@ -68,6 +72,8 @@ class Attr(object):
     def __get__(self, instance, cls):
         "Gets value from attribute, return None if attribute doesn't exist."
         value = instance._elem.attrib.get(self.name)
+        if value is not None:
+            return escape(value)
         return value
 
     def __set__(self, instance, value):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
         return ''
 
 setup(name='junitparser',
-      version="1.3.2",
+      version="1.3.3",
       description='Manipulates JUnit/xUnit Result XML files',
       long_description=read('README.rst'),
       classifiers=[

--- a/test.py
+++ b/test.py
@@ -364,6 +364,14 @@ class Test_TestSuite(unittest.TestCase):
             self.assertEqual(prop.name, 'name1')
             self.assertEqual(prop.value, 'value1')
 
+
+    def test_quoted_attr(self):
+        text = """<testsuite name="suitename with &quot;quotes&quot;">
+        </testsuite>"""
+        suite = TestSuite.fromstring(text)
+        self.assertEqual(suite.name, 'suitename with &quot;quotes&quot;')
+
+
     def test_len(self):
         text = """<testsuite name="suitename"><testcase name="testname"/>
         <testcase name="testname2"/>


### PR DESCRIPTION
Encode htmlentities when fetching attribute values.

A solution to #27 
