### PR TITLE
Adding isinstance() check before appending result

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -640,7 +640,8 @@ class TestCase(Element):
             if result is not None:
                 self.remove(result)
         # Then add current result
-        self.append(value)
+        if isinstance(value, System):
+            self.append(value)
 
     @property
     def system_out(self):


### PR DESCRIPTION
My test function in question returns either `Failure()`, `Error()`, `Skipped()` or `None`. Where `None` indicates a 'pass'. The result of my test function is directly fed into `testcase.result`. 

With the current implementation in junitparser this raises an error: `AttributeError: 'NoneType' object has no attribute '_elem'`. In short, returning anything else than `Failure()`, `Error()` or `Skipped()` results in a similar error. Since before appending the current result, the type is not checked. 

For robustness I suggest adding the the `isinstance()` check before appending the current result.