### PR TITLE
Changed isinstance() check to Skipped, Failure and Error types

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -640,7 +640,7 @@ class TestCase(Element):
             if result is not None:
                 self.remove(result)
         # Then add current result
-        if isinstance(value, System):
+        if isinstance(value, Skipped) or isinstance(value, Failure) or isinstance(value, Error):
             self.append(value)
 
     @property


### PR DESCRIPTION
In an earlier PR I proposed to add the `isinstance()` check before appending the test result. In fact, the value is now being checked against the wrong instance. So, the result will never be appended since `value` is not an instance of `System`. 

Solution: `value` should be an instance of `Skipped`, `Failure` or `Error`. 