### PR TITLE
Improve robustness result equality check

### DIFF
--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -567,9 +567,9 @@ class Skipped(Result):
     _tag = "skipped"
 
     def __eq__(self, other):
-        if (isinstance(other, Skipped):
+        if (isinstance(other, Skipped)):
             return super(Skipped, self).__eq__(other)
-        else
+        else:
             return false
 
 
@@ -578,7 +578,7 @@ class Failure(Result):
     _tag = "failure"
 
     def __eq__(self, other):
-        if (isinstance(other, Failure):
+        if (isinstance(other, Failure)):
             return super(Failure, self).__eq__(other)
         else:
             return false
@@ -589,7 +589,7 @@ class Error(Result):
     _tag = "error"
 
     def __eq__(self, other):
-        if (isinstance(other, Error):
+        if (isinstance(other, Error)):
             return super(Error, self).__eq__(other)
         else:
             return false

--- a/junitparser/junitparser.py
+++ b/junitparser/junitparser.py
@@ -567,7 +567,10 @@ class Skipped(Result):
     _tag = "skipped"
 
     def __eq__(self, other):
-        return super(Skipped, self).__eq__(other)
+        if (isinstance(other, Skipped):
+            return super(Skipped, self).__eq__(other)
+        else
+            return false
 
 
 class Failure(Result):
@@ -575,7 +578,10 @@ class Failure(Result):
     _tag = "failure"
 
     def __eq__(self, other):
-        return super(Failure, self).__eq__(other)
+        if (isinstance(other, Failure):
+            return super(Failure, self).__eq__(other)
+        else:
+            return false
 
 
 class Error(Result):
@@ -583,7 +589,10 @@ class Error(Result):
     _tag = "error"
 
     def __eq__(self, other):
-        return super(Error, self).__eq__(other)
+        if (isinstance(other, Error):
+            return super(Error, self).__eq__(other)
+        else:
+            return false
 
 
 POSSIBLE_RESULTS = {Failure, Error, Skipped}


### PR DESCRIPTION
Added `isinstance()` check to the `Skipped`, `Failure` and `Error` classes. This prevents python from raising an exception when the equality check is performed on an object of `other` which is not any of the classes mentioned.